### PR TITLE
no try to decode_json any false value

### DIFF
--- a/lib/Mojolicious/Command/openapi.pm
+++ b/lib/Mojolicious/Command/openapi.pm
@@ -68,7 +68,7 @@ sub run {
     }
   );
 
-  my $tx = $self->_client->$op(\%parameters, defined $content ? (body => decode_json $content) : ());
+  my $tx = $self->_client->$op(\%parameters, $content ? (body => decode_json $content) : ());
   if ($tx->error and $tx->error->{message} eq 'Invalid input') {
     _warn _header($tx->req), _header($tx->res) if $verbose;
   }


### PR DESCRIPTION
Raison d'etre: when installing `OpenAPI::Client` in a Docker container, this code:

```
  $content //= !-t STDIN && select($r, undef, undef, 0) ? join '', <STDIN> : undef;
```

gets, while running the tests, not `undef` but an empty string. `decode_json` is currently called on all defined values, and throws an exception. I cannot see any reason to try to decode any value that is false.