### PR TITLE
Add warning for paths without operationId

### DIFF
--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -82,7 +82,10 @@ HERE
     for my $http_method (keys %{$validator->get([paths => $path])}) {
       next if $http_method =~ $X_RE or $http_method eq 'parameters';
       my %op_spec = %{$validator->get([paths => $path => $http_method])};
-      my $operation_id = $op_spec{operationId} or next;
+      my $operation_id = $op_spec{operationId} or do {
+        warn "[$class] Skipping because operationId is not set for $http_method $path\n" if DEBUG;
+        next;
+      };
 
       $op_spec{method}     = lc $http_method;
       $op_spec{parameters} = [@$path_parameters, @{$op_spec{parameters} || []}];


### PR DESCRIPTION
Hello! I was trying out OpenAPI::Client, and I had to add a bunch of dump statements to figure out why it wasn't creating any methods for the paths in the specfile. It turned out to be because the specfile wasn't setting operationId, which is required by the client to generate methods. Hopefully this will help out anyone trying to figure this out in the future.

Let me know if there's anything I should change.

Cheers!