### PR TITLE
Always return a promise from call_p 

### DIFF
--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -36,7 +36,8 @@ sub call {
 
 sub call_p {
   my ($self, $op) = (shift, shift);
-  my $code = $self->can("${op}_p") or Carp::croak('[OpenAPI::Client] No such operationId');
+  my $code = $self->can("${op}_p") or
+    return Mojo::Promise->reject('[OpenAPI::Client] No such operationId');
   return $self->$code(@_);
 }
 

--- a/t/client.t
+++ b/t/client.t
@@ -88,6 +88,15 @@ $promise->wait;
 is_deeply $results[0]->res->json, [{page => 2}], 'call_p(list pets)';
 is_deeply \@errors, [], 'promise not rejected';
 
+note 'call_p() rejecting';
+$promise = $client->call_p('list all pets', {page => 2});
+(@results, @errors) = ();
+$promise->then(sub { @results = @_ }, sub { @errors = @_ });
+$promise->wait;
+is_deeply \@results, [], 'call_p(list all pets) does not exist';
+is_deeply \@errors, ['[OpenAPI::Client] No such operationId'],
+  'promise got rejected';
+
 done_testing;
 
 __DATA__


### PR DESCRIPTION
As per #24 this PR removes the croak in favour of returning a rejected promise.