### PR TITLE
Support for OpenAPIv3

### DIFF
--- a/lib/Mojolicious/Command/openapi.pm
+++ b/lib/Mojolicious/Command/openapi.pm
@@ -146,7 +146,7 @@ Mojolicious::Command::openapi - Perform Open API requests
                                          of MOJO_CONNECT_TIMEOUT or 10
     -p, --parameter <name=value>         Specify multiple header, path, or
                                          query parameter
-    -s, --schema-version <schema>        Open API spec version
+    -s, --schema <schema>                Open API spec version
                                          defaults to v2
     -S, --response-size <size>           Maximum response size in bytes,
                                          defaults to 2147483648 (2GB)

--- a/lib/Mojolicious/Command/openapi.pm
+++ b/lib/Mojolicious/Command/openapi.pm
@@ -41,6 +41,7 @@ sub run {
     'p|parameter=s'          => \my %parameters,
     'c|content=s'            => \my $content,
     'S|response-size=i'      => sub { $ua{max_response_size} = $_[1] },
+    's|schema-version=s'     => \my $schema,
     'v|verbose'              => \my $verbose;
 
   # Read body from STDIN
@@ -54,7 +55,7 @@ sub run {
   die $self->usage unless $client_args[0];
 
   push @client_args, app => $self->app if $client_args[0] =~ m!^/! and !-e $client_args[0];
-  $self->_client(OpenAPI::Client->new(@client_args));
+  $self->_client(OpenAPI::Client->new(@client_args, schema => $schema));
   return $self->_info($info_about) if $info_about;
   return $self->_list unless $op;
   die qq(Unknown operationId "$op".\n) unless $self->_client->can($op);
@@ -145,6 +146,8 @@ Mojolicious::Command::openapi - Perform Open API requests
                                          of MOJO_CONNECT_TIMEOUT or 10
     -p, --parameter <name=value>         Specify multiple header, path, or
                                          query parameter
+    -s, --schema-version <schema>        Open API spec version
+                                         defaults to v2
     -S, --response-size <size>           Maximum response size in bytes,
                                          defaults to 2147483648 (2GB)
     -v, --verbose                        Print request and response headers to

--- a/lib/Mojolicious/Command/openapi.pm
+++ b/lib/Mojolicious/Command/openapi.pm
@@ -41,7 +41,7 @@ sub run {
     'p|parameter=s'          => \my %parameters,
     'c|content=s'            => \my $content,
     'S|response-size=i'      => sub { $ua{max_response_size} = $_[1] },
-    's|schema-version=s'     => \my $schema,
+    's|schema=s'             => \my $schema,
     'v|verbose'              => \my $verbose;
 
   # Read body from STDIN

--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -201,7 +201,7 @@ sub _build_tx {
 
   # Handling requestBody for OpenAPIv3
   if ($op_spec->{requestBody}) {
-    my $content_key = [keys $op_spec->{requestBody}{content}->%*]->[0];
+    my $content_key = [keys %{$op_spec->{requestBody}{content}}]->[0];
     my $ct          = {'application/x-www-form-urlencoded' => 'form', 'application/json' => 'json'}->{$content_key};
 
     my $properties    = $op_spec->{requestBody}{content}{$content_key}{schema}{properties};
@@ -209,7 +209,7 @@ sub _build_tx {
 
     for my $name (keys %$properties) {
       my $schema   = $properties->{$name};
-      my $required = grep { $name eq $_ } $required_list->@*;
+      my $required = grep { $name eq $_ } @{$required_list};
       if (exists $params->{$name} or $required) {
         my @e = $v->validate($params,
           {type => 'object', required => $required ? [$name] : [], properties => {$name => $schema}});

--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -23,7 +23,8 @@ has base_url => sub {
 
   # Schema loaded is an OpenAPIv3 spec
   if ($schema->get('/openapi')) {
-    $url = Mojo::URL->new($schema->get('/servers')->[0]{url});
+    my $servers = $schema->get('/servers') || [];
+    $url = Mojo::URL->new($servers->[0] ? $servers->[0]{url} : '/');
     $url->host('localhost')->scheme('http') unless $url->host;
   }
   else {

--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -307,6 +307,28 @@ C<host>, C<basePath> and the first item in C<schemes> will be used to construct
 L</base_url>. This can be altered at any time, if you need to send data to a
 custom endpoint.
 
+Working with Open API v3 L</base_url> is taken from the first entry from C<url>
+in C<servers>. Here is an example of a corresponding Open API v3 spec:
+
+  ---
+  openapi: 3.0.0
+  info:
+    version: "0.8"
+    title: Test client spec
+  servers:
+    - url: http://api.example.com:3000/v1
+  paths:
+    /pets:
+      get:
+        operationId: listPets
+        parameters:
+          - in: query
+            name: page
+            schema:
+              type: integer
+        responses:
+          "200": { ... }
+
 =head2 Client
 
 The OpenAPI API specification will be used to generate a sub-class of
@@ -327,6 +349,11 @@ used to generate methods:
 
   # With parameters
   $tx = $client->listPets({limit => 10});
+
+Working with an Open API v3 spec, you need to specify the schema version:
+
+  use OpenAPI::Client;
+  $client = OpenAPI::Client->new("file:///path/to/api.json", schema => 'v3');
 
 See L<Mojo::Transaction> for more information about what you can do with the
 C<$tx> object, but you often just want something like this:

--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -203,7 +203,7 @@ sub _build_tx {
   # Handling requestBody for OpenAPIv3
   if ($op_spec->{requestBody}) {
     my $content_key = [keys %{$op_spec->{requestBody}{content}}]->[0];
-    my $ct          = {'application/x-www-form-urlencoded' => 'form', 'application/json' => 'json'}->{$content_key};
+    my $ct          = $content_key eq 'application/x-www-form-urlencoded' ? 'form' : 'json';
 
     my $properties    = $op_spec->{requestBody}{content}{$content_key}{schema}{properties};
     my $required_list = $op_spec->{requestBody}{content}{$content_key}{schema}{required} || [];

--- a/t/client_v3.t
+++ b/t/client_v3.t
@@ -34,6 +34,23 @@ is(OpenAPI::Client->new('data://main/test.json', schema => 'v3')->base_url,     
 is(OpenAPI::Client->new('data://main/test.json', schema => 'v3')->base_url->host, 'api.example.com',                'base_url host');
 is(OpenAPI::Client->new('data://main/test.json', schema => 'v3')->base_url->port, '3000',                           'base_url port');
 
+note 'servers not defined';
+is(OpenAPI::Client->new('data://main/test_no_servers_defined.json', schema => 'v3')->base_url,
+  'http://localhost/', 'base_url');
+is(OpenAPI::Client->new('data://main/test_no_servers_defined.json', schema => 'v3')->base_url->host,
+  'localhost', 'base_url host');
+is(OpenAPI::Client->new('data://main/test_no_servers_defined.json', schema => 'v3')->base_url->port,
+  undef, 'base_url port');
+
+note 'servers empty array';
+is(OpenAPI::Client->new('data://main/test_no_servers_defined.json', schema => 'v3')->base_url,
+  'http://localhost/', 'base_url');
+is(OpenAPI::Client->new('data://main/test_empty_servers.json', schema => 'v3')->base_url,
+  'http://localhost/', 'base_url');
+is(OpenAPI::Client->new('data://main/test_empty_servers.json', schema => 'v3')->base_url->host,
+  'localhost', 'base_url host');
+is(OpenAPI::Client->new('data://main/test_empty_servers.json', schema => 'v3')->base_url->port, undef, 'base_url port');
+
 my $client = OpenAPI::Client->new('data://main/test.json', app => app, schema => 'v3');
 my ($obj, $tx);
 
@@ -253,6 +270,83 @@ __DATA__
       "ok": {
         "type": "array",
         "items": {}
+      }
+    }
+  }
+}
+
+@@ test_no_servers_defined.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "0.8",
+    "title": "Test client spec"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "list pets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@@ test_empty_servers.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "0.8",
+    "title": "Test client spec"
+  },
+  "servers": [],
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "list pets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/t/client_v3.t
+++ b/t/client_v3.t
@@ -1,0 +1,259 @@
+use Mojo::Base -strict;
+use Mojo::JSON 'true';
+use OpenAPI::Client;
+use Test::More;
+
+use Mojolicious::Lite;
+app->log->level('error') unless $ENV{HARNESS_IS_VERBOSE};
+
+my $i = 0;
+get '/pets/:type' => sub {
+  $i++;
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => [{type => $c->param('type')}]);
+  },
+  'listPetsByType';
+
+get '/pets' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => [$c->req->params->to_hash]);
+  },
+  'list pets';
+
+post '/pets' => sub {
+  my $c   = shift->openapi->valid_input or return;
+  my $res = $c->req->body_params->to_hash;
+  $res->{dummy} = true if $c->req->headers->header('x-dummy');
+  $c->render(openapi => $res);
+  },
+  'addPet';
+
+plugin OpenAPI => {url => 'data://main/test.json', schema => 'v3'};
+
+is(OpenAPI::Client->new('data://main/test.json', schema => 'v3')->base_url,       'http://api.example.com:3000/v1', 'base_url');
+is(OpenAPI::Client->new('data://main/test.json', schema => 'v3')->base_url->host, 'api.example.com',                'base_url host');
+is(OpenAPI::Client->new('data://main/test.json', schema => 'v3')->base_url->port, '3000',                           'base_url port');
+
+my $client = OpenAPI::Client->new('data://main/test.json', app => app, schema => 'v3');
+my ($obj, $tx);
+
+is +ref($client), 'OpenAPI::Client::main_test_json', 'generated class';
+isa_ok($client, 'OpenAPI::Client');
+can_ok($client, 'addPet');
+
+note 'Sync testing';
+$tx = $client->listPetsByType;
+is $tx->res->code, 400, 'sync invalid listPetsByType';
+is $tx->error->{message}, 'Invalid input', 'sync invalid message';
+is $i, 0, 'invalid on client side';
+
+$tx = $client->listPetsByType({type => 'dog', p => 12});
+
+is $tx->res->code, 200, 'sync listPetsByType';
+is $tx->req->url->query->param('p'), 12, 'sync listPetsByType p=12';
+is $i, 1, 'one request';
+
+$tx = $client->addPet({age => '5', type => 'dog', name => 'Pluto', 'x-dummy' => true});
+is $tx->res->code, 200, 'coercion for "age":"5" works';
+
+$tx = $client->addPet({age => '5', type => 'dog', 'x-dummy' => true});
+is $tx->res->code, 400, 'missing required name addPet';
+is $tx->error->{message}, 'Invalid input', 'sync invalid message';
+
+note 'Async testing';
+$i = 0;
+is $client->listPetsByType(sub { ($obj, $tx) = @_; Mojo::IOLoop->stop }), $client, 'async request';
+Mojo::IOLoop->start;
+is $obj, $client, 'got client in callback';
+is $tx->res->code, 400, 'invalid listPetsByType';
+is $tx->error->{message}, 'Invalid input', 'sync invalid message';
+is $i, 0, 'invalid on client side';
+
+note 'Promise testing';
+my $p = $client->listPetsByType_p->then(sub { $tx = shift });
+$tx = undef;
+$p->wait;
+is $tx->res->code, 400, 'invalid listPetsByType';
+is $tx->error->{message}, 'Invalid input', 'sync invalid message';
+is $i, 0, 'invalid on client side';
+
+note 'call()';
+$tx = $client->call('list pets', {page => 2});
+is_deeply $tx->res->json, [{page => 2}], 'call(list pets)';
+
+eval { $tx = $client->call('nope') };
+like $@, qr{No such operationId.*client_v3\.t}, 'call(nope)';
+
+# this approach from https://metacpan.org/source/SRI/Mojolicious-7.59/t/mojo/promise.t and user_agent.t
+note 'call_p()';
+my $promise = $client->call_p('list pets', {page => 2});
+my (@results, @errors);
+$promise->then(sub { @results = @_ }, sub { @errors = @_ });
+$promise->wait;
+is_deeply $results[0]->res->json, [{page => 2}], 'call_p(list pets)';
+is_deeply \@errors, [], 'promise not rejected';
+
+note 'call_p() rejecting';
+$promise = $client->call_p('list all pets', {page => 2});
+(@results, @errors) = ();
+$promise->then(sub { @results = @_ }, sub { @errors = @_ });
+$promise->wait;
+is_deeply \@results, [], 'call_p(list all pets) does not exist';
+is_deeply \@errors, ['[OpenAPI::Client] No such operationId'], 'promise got rejected';
+
+note 'boolean';
+my $err;
+$client->listPetsByType_p({type => 'cat', is_cool => true})->then(sub { $tx = shift }, sub { $err = shift })->wait;
+is $tx->res->code, 200, 'accepted is_cool=true';
+is $tx->req->url->query->to_string, 'is_cool=1', 'is_cool in query parameter';
+
+done_testing;
+
+__DATA__
+@@ test.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "0.8",
+    "title": "Test client spec"
+  },
+  "paths": {
+    "x-whatever": [],
+    "/pets": {
+      "x-whatever": [],
+      "parameters": [],
+      "get": {
+        "operationId": "list pets",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "x-whatever": [],
+        "operationId": "addPet",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-dummy",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "age": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{type}": {
+      "get": {
+        "operationId": "listPetsByType",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "is_cool",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/p"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ok"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://api.example.com:3000/v1"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "p": {
+        "in": "query",
+        "name": "p",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
+    "schemas": {
+      "ok": {
+        "type": "array",
+        "items": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Due to the structure change in OpenAPI v3, body parameters has been moved to 'RequestBody'

This PR handles this fact, and brings the missing OpenAPIv3 support 