### PR TITLE
Allow pre-BUILD mixins

### DIFF
--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -57,7 +57,6 @@ sub validator { Carp::confess("validator() is not defined for $_[0]") }
 
 sub _generate_class {
   my ($parent, $class, $specification, $attrs) = @_;
-  $parent = ref $parent if ref $parent;
 
   my $jv = JSON::Validator->new;
   $jv->coerce($attrs->{coerce} // 'booleans,numbers,strings');
@@ -198,7 +197,6 @@ sub _param_as_array {
 
 sub _url_to_class {
   my ($self, $package) = @_;
-  $self = ref $self if ref $self;
 
   $package =~ s!^\w+?://!!;
   $package =~ s!\W!_!g;

--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -11,8 +11,6 @@ use constant DEBUG => $ENV{OPENAPI_CLIENT_DEBUG} || 0;
 
 our $VERSION = '1.03';
 
-my $BASE = __PACKAGE__;
-
 has base_url => sub {
   my $self      = shift;
   my $validator = $self->validator;
@@ -37,11 +35,11 @@ sub call_p {
 }
 
 sub new {
-  my ($class, $specification) = (shift, shift);
+  my ($parent, $specification) = (shift, shift);
   my $attrs = @_ == 1 ? shift : {@_};
 
-  $class = $class->_url_to_class($specification);
-  _generate_class($class, $specification, $attrs) unless $class->isa($BASE);
+  my $class = $parent->_url_to_class($specification);
+  $parent->_generate_class($class, $specification, $attrs) unless $class->isa($parent);
 
   my $self = $class->SUPER::new($attrs);
   $self->base_url(Mojo::URL->new($self->{base_url})) if $self->{base_url} and !blessed $self->{base_url};
@@ -58,7 +56,8 @@ sub new {
 sub validator { Carp::confess("validator() is not defined for $_[0]") }
 
 sub _generate_class {
-  my ($class, $specification, $attrs) = @_;
+  my ($parent, $class, $specification, $attrs) = @_;
+  $parent = ref $parent if ref $parent;
 
   my $jv = JSON::Validator->new;
   $jv->coerce($attrs->{coerce} // 'booleans,numbers,strings');
@@ -69,7 +68,7 @@ sub _generate_class {
 
   eval <<"HERE" or Carp::confess("package $class: $@");
 package $class;
-use Mojo::Base '$BASE';
+use Mojo::Base '$parent';
 1;
 HERE
 
@@ -199,12 +198,13 @@ sub _param_as_array {
 
 sub _url_to_class {
   my ($self, $package) = @_;
+  $self = ref $self if ref $self;
 
   $package =~ s!^\w+?://!!;
   $package =~ s!\W!_!g;
   $package = Mojo::Util::md5_sum($package) if length $package > 110;    # 110 is a bit random, but it cannot be too long
 
-  return "$BASE\::$package";
+  return "$self\::$package";
 }
 
 1;

--- a/t/client.t
+++ b/t/client.t
@@ -50,7 +50,6 @@ subtest 'pre-mixing roles' => sub {
   my $old_client = OpenAPI::Client->new('data://main/test.json');
   my $new_client = OpenAPI::Client->with_roles('TestRole')->new('data://main/test.json');
   can_ok($new_client, 'frobnicate');
-  $new_client->new('data://main/test.json');
   ok(!$old_client->can('frobnicate'), 'does not bleed over');
 };
 

--- a/t/client.t
+++ b/t/client.t
@@ -38,8 +38,21 @@ my $client = OpenAPI::Client->new('data://main/test.json', app => app);
 my ($obj, $tx);
 
 is +ref($client), 'OpenAPI::Client::main_test_json', 'generated class';
+
 isa_ok($client, 'OpenAPI::Client');
 can_ok($client, 'addPet');
+
+subtest 'pre-mixing roles' => sub {
+  package TestRole {
+    use Mojo::Base -role;
+    sub frobnicate {}
+  }
+  my $old_client = OpenAPI::Client->new('data://main/test.json');
+  my $new_client = OpenAPI::Client->with_roles('TestRole')->new('data://main/test.json');
+  can_ok($new_client, 'frobnicate');
+  $new_client->new('data://main/test.json');
+  ok(!$old_client->can('frobnicate'), 'does not bleed over');
+};
 
 note 'Sync testing';
 $tx = $client->listPetsByType;

--- a/t/client.t
+++ b/t/client.t
@@ -42,13 +42,13 @@ is +ref($client), 'OpenAPI::Client::main_test_json', 'generated class';
 isa_ok($client, 'OpenAPI::Client');
 can_ok($client, 'addPet');
 
-subtest 'pre-mixing roles' => sub {
-  package TestRole {
-    use Mojo::Base -role;
+subtest 'subclassing' => sub {
+  package OpenAPI::Child {
+    use Mojo::Base 'OpenAPI::Client';
     sub frobnicate {}
   }
   my $old_client = OpenAPI::Client->new('data://main/test.json');
-  my $new_client = OpenAPI::Client->with_roles('TestRole')->new('data://main/test.json');
+  my $new_client = OpenAPI::Child->new('data://main/test.json');
   can_ok($new_client, 'frobnicate');
   ok(!$old_client->can('frobnicate'), 'does not bleed over');
 };


### PR DESCRIPTION
This is an implementation of what I meant for #35. Again, the issue I was having is that I
wanted to mix in a role which had defaults for attributes and other things that would
normally happen at BUILD time. Since I could only mix the behavior in after instantiation,
I had to manually pass through some of the behavior that I wanted to.

This PR simply replaces the fixed $BASE that OpenAPI::Client uses to be the parent for
generated class to instead be the dynamic one that's called.
