### PR TITLE
Autogenerated operation_id

### DIFF
--- a/lib/OpenAPI/Client.pm
+++ b/lib/OpenAPI/Client.pm
@@ -75,10 +75,18 @@ HERE
   return unless $schema->can('routes');    # In case it is not an OpenAPI spec
 
   for my $route ($schema->routes->each) {
-    next unless $route->{operation_id};
-    warn "[$class] Add method $route->{operation_id}() for $route->{method} $route->{path}\n" if DEBUG;
-    $class->_generate_method_bnb($route->{operation_id} => $route);
-    $class->_generate_method_p("$route->{operation_id}_p" => $route);
+    my $operation_id = $route->{operation_id};
+
+    unless ( $route->{operation_id} ) {
+      $operation_id = join '_', $route->{method}, $route->{path};
+      $operation_id =~ s|\{[^}]+\}|_|g;
+      $operation_id =~ s|[/-]|_|g;
+      $operation_id =~ s|__+|_|g;
+    }
+
+    warn "[$class] Add method $operation_id() for $route->{method} $route->{path}\n" if DEBUG;
+    $class->_generate_method_bnb($operation_id => $route);
+    $class->_generate_method_p("${operation_id}_p" => $route);
   }
 }
 


### PR DESCRIPTION
Hi there! Thank you for the great piece of code you've done.

I am often working with vendor provided API specification, which have some issues.
Unfortunately these specs are too big and updates frequently to fix them manually.
One of the most often issues I met was missing operationId, which is not required as of OpenAPI spec 3.0.1

Now OpenAPI::Client just silently skips such operations, I propose to autogenerate some operationId in this case.
Tried to make them readable:
1. Take first verb from method
2. Remove {params} from path
3. Convert all slashes and dashes to underscore